### PR TITLE
Add `launchSettings.json`

### DIFF
--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Windows Machine": {
+      "commandName": "MsixPackage",
+      "nativeDebugging": false
+    }
+  }
+}


### PR DESCRIPTION
Fixes #15 
Fixes #14 

The `launchSettings.json` file is required to run on Windows, however the `.gitignore` file can sometimes cause `git` to ignore adding + pushing this file to GitHub.